### PR TITLE
Added Kirby driver

### DIFF
--- a/src/Drivers/KirbyTinkerwellDriver.php
+++ b/src/Drivers/KirbyTinkerwellDriver.php
@@ -1,0 +1,37 @@
+<?php
+
+use Tinkerwell\ContextMenu\Label;
+use Tinkerwell\ContextMenu\OpenURL;
+
+class KirbyTinkerwellDriver extends TinkerwellDriver
+{
+    public function canBootstrap($projectPath)
+    {
+        return file_exists($projectPath . '/kirby/bootstrap.php');
+    }
+
+    public function bootstrap($projectPath)
+    {
+        require $projectPath . '/kirby/bootstrap.php';
+        (new Kirby)->render();
+    }
+
+    public function getAvailableVariables()
+    {
+        return [
+            'site' => site(),
+            'kirby' => kirby(),
+        ];
+    }
+
+    public function contextMenu()
+    {
+        return [
+            Label::create('Detected Kirby v.' . Kirby::version()),
+
+            OpenURL::create('Kirby Guide', 'https://getkirby.com/docs/guide'),
+
+            OpenURL::create('Kirby Reference', 'https://getkirby.com/docs/reference'),
+        ];
+    }
+}


### PR DESCRIPTION
Added support for Kirby CMS.

- `$site` and `$kirby` variables are available to Tinkerwell.
- Links to the documentations are available in context menu.