### PR TITLE
Statamic driver tweaks

### DIFF
--- a/src/Drivers/StatamicTinkerwellDriver.php
+++ b/src/Drivers/StatamicTinkerwellDriver.php
@@ -1,5 +1,7 @@
 <?php
 
+use Statamic\Statamic;
+use Statamic\Support\Str;
 use Tinkerwell\ContextMenu\Label;
 use Tinkerwell\ContextMenu\OpenURL;
 use Tinkerwell\ContextMenu\SetCode;
@@ -15,22 +17,20 @@ class StatamicTinkerwellDriver extends LaravelTinkerwellDriver
     public function contextMenu()
     {
         return array_merge(parent::contextMenu(), [
-            Label::create('Detected Statamic v' . \Statamic\Statamic::version()),
+            Label::create('Detected Statamic v' . Statamic::version()),
 
             Submenu::create(
                 'Please',
                 collect(Artisan::all())
                     ->filter(function ($command, $key) {
-                        $length = strlen('statamic');
-
-                        return (substr($key, 0, $length) === 'statamic');
+                        return Str::startsWith($key, 'statamic:');
                     })
                     ->map(function ($command, $key) {
-                        return SetCode::create($key, "Artisan::call('" . $key . "', []);\nArtisan::output();");
+                        return SetCode::create(Str::after($key, 'statamic:'), "Artisan::call('" . $key . "', []);\nArtisan::output();");
                     })->values()->toArray()
             ),
 
-            OpenURL::create('Statamic Docs', 'https://statamic.dev'),
+            OpenURL::create('Documentation', Statamic::docsUrl('/')),
         ]);
     }
 }


### PR DESCRIPTION
- Simplify filtering
- Strip off `statamic:` command prefix inside the Please list. They're all gonna be statamic commands.
- Rename docs item to "Documentation" to be consistent with the Laravel menu items.
- Use a helper method rather than hardcoding the URL.