### PR TITLE
Alias Statamic\Facades namespace

### DIFF
--- a/src/Drivers/StatamicTinkerwellDriver.php
+++ b/src/Drivers/StatamicTinkerwellDriver.php
@@ -11,7 +11,12 @@ use Tinkerwell\ContextMenu\Separator;
 class StatamicTinkerwellDriver extends LaravelTinkerwellDriver
 {
     protected $aliasMap;
-    protected $aliases = ['Statamic\Facades'];
+    protected $aliases = [
+        'App\\',
+        'Statamic\Facades',
+        'Statamic\Support\Arr',
+        'Statamic\Support\Str',
+    ];
 
     public function bootstrap($projectPath)
     {

--- a/src/Drivers/StatamicTinkerwellDriver.php
+++ b/src/Drivers/StatamicTinkerwellDriver.php
@@ -60,7 +60,7 @@ class StatamicTinkerwellDriver extends LaravelTinkerwellDriver
             return Str::startsWith($class, $this->aliases);
         })->map(function ($path, $original) {
             return class_basename($original);
-        })->flip();
+        })->unique()->flip();
 
         spl_autoload_register([$this, 'aliasClass']);
     }


### PR DESCRIPTION
As per the request in https://github.com/beyondcode/tinkerwell-suggestions/issues/93 this PR  adds aliasing to the Statamic driver.

![image](https://user-images.githubusercontent.com/105211/74688286-157a1f00-51a5-11ea-8ee8-751511c09d45.png)

If you wanted to, moving the `registerAliases` and `aliasClass` methods into your abstract driver class could make it reusable. Then drivers could just add an `$aliases` array. Or not. :) That's cool too.

Anyway, here it is just for Statamic.
Supports `App\*`, `Statamic\Facades\*`, `Statamic\Support\Arr`, and `Statamic\Support\Str`.