### PR TITLE
Fix WordPress version in context menu

### DIFF
--- a/src/Drivers/WordpressTinkerwellDriver.php
+++ b/src/Drivers/WordpressTinkerwellDriver.php
@@ -25,7 +25,7 @@ class WordpressTinkerwellDriver extends TinkerwellDriver
     public function contextMenu()
     {
         return [
-            Label::create('Detected Wordpress v' . bloginfo('version')),
+            Label::create('Detected Wordpress v' . get_bloginfo('version')),
         ];
     }
 }


### PR DESCRIPTION
The context menu in the current implementation of the WordPress driver doesn't work. This is because it has a call to `bloginfo()` which is just a wrapper that echoes the response from `get_bloginfo()`. This PR just fixes that so it will correctly output the current WP version. 

One other thing to note that isn't a huge deal (but is correct for PrestaShop): WordPress has a capital P, but the filename is `WordpressTinkerwellDriver.php`. 