### PR TITLE
Load local Kirby instance

### DIFF
--- a/src/Drivers/KirbyTinkerwellDriver.php
+++ b/src/Drivers/KirbyTinkerwellDriver.php
@@ -12,8 +12,11 @@ class KirbyTinkerwellDriver extends TinkerwellDriver
 
     public function bootstrap($projectPath)
     {
-        require $projectPath . '/kirby/bootstrap.php';
-        (new Kirby)->render();
+        if (file_exists($publicIndexFile = $projectPath . '/public/index.php')) {
+            require $publicIndexFile;
+        } else {
+            require $projectPath . '/index.php';
+        }
     }
 
     public function getAvailableVariables()


### PR DESCRIPTION
The current driver creates its own Kirby instance. This breaks projects where Kirby is initialized with custom options.

This PR loads the local `index.php` where the Kirby instance is created. It also supports the `/public` directory setup.

I have tested this change via a `CustomTinkerwellDriver` and it works well.