### PR TITLE
Use boostrap/autoload.php in LaravelTinkerwellDriver to keep consistent with Laravel

### DIFF
--- a/src/Drivers/LaravelTinkerwellDriver.php
+++ b/src/Drivers/LaravelTinkerwellDriver.php
@@ -15,7 +15,7 @@ class LaravelTinkerwellDriver extends TinkerwellDriver
 
     public function bootstrap($projectPath)
     {
-        require_once $projectPath . '/vendor/autoload.php';
+        require_once $projectPath . '/bootstrap/autoload.php';
 
         $app = require_once $projectPath . '/bootstrap/app.php';
 


### PR DESCRIPTION
Our Laravel application has some code in bootstrap/autoload.php to override one of the Laravel global helper methods. When we run scripts in Tinkerwell, the helper overrides aren't loaded.

Requiring the Composer autoloader through `bootstrap/autoload.php` is consistent with `/artisan` and `/public/index.php`