### PR TITLE
Update symfony driver

### DIFF
--- a/src/Drivers/SymfonyTinkerwellDriver.php
+++ b/src/Drivers/SymfonyTinkerwellDriver.php
@@ -4,37 +4,36 @@ use Tinkerwell\ContextMenu\Label;
 use Tinkerwell\ContextMenu\OpenURL;
 use Tinkerwell\ContextMenu\SetCode;
 use Tinkerwell\ContextMenu\Submenu;
-use Symfony\Component\HttpFoundation\Request;
+use App\Kernel;
+use Symfony\Component\Dotenv\Dotenv;
 
 class SymfonyTinkerwellDriver extends TinkerwellDriver
 {
+    protected $kernel;
+
     public function canBootstrap($projectPath)
     {
         return file_exists($projectPath . '/public/index.php') &&
-            file_exists($projectPath . '/config/bootstrap.php') &&
             file_exists($projectPath . '/symfony.lock') &&
             file_exists($projectPath . '/bin/console');
     }
 
     public function bootstrap($projectPath)
     {
-        require_once $projectPath . '/config/bootstrap.php';
-        
-        if ($_SERVER['APP_DEBUG']) {
-            umask(0000);
-        
-            Symfony\Component\ErrorHandler\Debug::enable();
-        }
-        
-        if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false) {
-            Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
-        }
-        
-        if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false) {
-            Request::setTrustedHosts([$trustedHosts]);
-        }
-        
-        $kernel = new App\Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+        require_once $projectPath.'/vendor/autoload.php';
+
+        (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+
+        $this->kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+        $this->kernel->boot();
+    }
+
+    public function getAvailableVariables()
+    {
+        return [
+            'kernel' => $this->kernel,
+            'container' => $this->kernel->getContainer(),
+        ];
     }
 
     public function contextMenu()


### PR DESCRIPTION
Since Symfony 5.1, the `bootstrap.php` is not present anymore and therefore the driver would not be sued at all. The changes in the bootstrap method were needed so that the framework gets bootstrapped at all – and Tinkerwell now exposes the kernel and container for easier access of the application