### PR TITLE
Fixes loading env file from the right folder

### DIFF
--- a/src/Drivers/SymfonyTinkerwellDriver.php
+++ b/src/Drivers/SymfonyTinkerwellDriver.php
@@ -22,7 +22,7 @@ class SymfonyTinkerwellDriver extends TinkerwellDriver
     {
         require_once $projectPath.'/vendor/autoload.php';
 
-        (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+        (new Dotenv())->bootEnv($projectPath.'/.env');
 
         $this->kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
         $this->kernel->boot();


### PR DESCRIPTION
I was getting the following exception upon loading a symfony project

```
PHP Fatal error: Uncaught Symfony\Component\Dotenv\Exception\PathException: Unable to read the "phar:///tmp/.mount_TinkergtKlam/resources/tinkerwell/tinker.phar/src/.env" environment file. in /home/krishankoenig/Workspace/tribecast/app.tribecast.fm/vendor/symfony/dotenv/Dotenv.php:557Stack trace:#0 /home/krishankoenig/Workspace/tribecast/app.tribecast.fm/vendor/symfony/dotenv/Dotenv.php(105): Symfony\Component\Dotenv\Dotenv->doLoad()#1 /home/krishankoenig/Workspace/tribecast/app.tribecast.fm/vendor/symfony/dotenv/Dotenv.php(148): Symfony\Component\Dotenv\Dotenv->loadEnv()#2 phar:///tmp/.mount_TinkergtKlam/resources/tinkerwell/tinker.phar/src/Drivers/SymfonyTinkerwellDriver.php(25): Symfony\Component\Dotenv\Dotenv->bootEnv()#3 phar:///tmp/.mount_TinkergtKlam/resources/tinkerwell/tinker.phar/src/Concerns/DriverAware.php(11): SymfonyTinkerwellDriver->bootstrap()#4 phar:///tmp/.mount_TinkergtKlam/resources/tinkerwell/tinker.phar/src/Actions/CliAction.php(27): _PhpScoperc223a629f245\Tinkerwell\Actions\CliAction->detectDriver()#5 phar:///tmp/.mount_TinkergtKlam/resources/tinkerwell/tinker.phar/src/ActionInvoker.php(37): _PhpScoperc223a629f245\Tinkerwell\Actions\CliAction->__construct()#6 phar:///tmp/.mount_TinkergtKlam/resources/tinkerwell/tinker.phar/src/ActionInvoker.php(18): _PhpScoperc223a629f245\Tinkerwell\ActionInvoker->setUpAction()#7 phar:///tmp/.mount_TinkergtKlam/resources/tinkerwell/tinker.phar/index.php(25): _PhpScoperc223a629f245\Tinkerwell\ActionInvoker->execute()#8 /tmp/.mount_TinkergtKlam/resources/tinkerwell/tinker.phar(12): require('...')#9 {main} thrown in /home/krishankoenig/Workspace/tribecast/app.tribecast.fm/vendor/symfony/dotenv/Dotenv.php on line 557
```